### PR TITLE
feat(gallery): add tag filtering

### DIFF
--- a/app/gallery/page.tsx
+++ b/app/gallery/page.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import GalleryGrid from "@/components/GalleryGrid";
+import GalleryFilter from "@/components/GalleryFilter";
 import { getAllPhotos } from "@/lib/photos";
 
 export const metadata: Metadata = {
@@ -26,7 +26,7 @@ export default function GalleryPage() {
       </div>
 
       {/* Gallery */}
-      <GalleryGrid photos={photos} />
+      <GalleryFilter photos={photos} />
     </div>
   );
 }

--- a/components/GalleryFilter.tsx
+++ b/components/GalleryFilter.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { useState, useMemo } from "react";
+import type { Photo } from "@/lib/photos";
+import PhotoCard from "@/components/PhotoCard";
+
+interface GalleryFilterProps {
+  photos: Photo[];
+}
+
+export default function GalleryFilter({ photos }: GalleryFilterProps) {
+  const [activeTag, setActiveTag] = useState<string | null>(null);
+
+  const allTags = useMemo(() => {
+    const tagSet = new Set<string>();
+    photos.forEach((p) => p.tags.forEach((t) => tagSet.add(t)));
+    return Array.from(tagSet).sort();
+  }, [photos]);
+
+  const filteredPhotos = activeTag
+    ? photos.filter((p) => p.tags.includes(activeTag))
+    : photos;
+
+  return (
+    <>
+      {/* Filter bar */}
+      <div className="flex flex-wrap gap-2">
+        <button
+          onClick={() => setActiveTag(null)}
+          className={`text-xs px-3 py-1.5 rounded-full border transition-colors ${
+            activeTag === null
+              ? "bg-[var(--accent-blue)] border-[var(--accent-blue)] text-white"
+              : "border-[var(--border-subtle)] text-[var(--text-muted)] hover:text-[var(--text-primary)] hover:border-[var(--text-muted)]"
+          }`}
+        >
+          All
+        </button>
+        {allTags.map((tag) => (
+          <button
+            key={tag}
+            onClick={() => setActiveTag(tag === activeTag ? null : tag)}
+            className={`text-xs px-3 py-1.5 rounded-full border transition-colors ${
+              activeTag === tag
+                ? "bg-[var(--accent-blue)] border-[var(--accent-blue)] text-white"
+                : "border-[var(--border-subtle)] text-[var(--text-muted)] hover:text-[var(--text-primary)] hover:border-[var(--text-muted)]"
+            }`}
+          >
+            {tag}
+          </button>
+        ))}
+      </div>
+
+      {/* Photo count */}
+      <p className="text-xs text-[var(--text-muted)]">
+        {filteredPhotos.length} photo{filteredPhotos.length !== 1 && "s"}
+        {activeTag && (
+          <>
+            {" "}tagged <span className="text-[var(--accent-gold)]">{activeTag}</span>
+          </>
+        )}
+      </p>
+
+      {/* Grid */}
+      <div className="masonry-grid">
+        {filteredPhotos.map((photo, i) => (
+          <PhotoCard
+            key={photo.id}
+            photo={photo}
+            linkable
+            priority={i < 4}
+          />
+        ))}
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds a **tag filter bar** at the top of the gallery page
- Click a tag to filter photos; click again or press "All" to reset
- Shows filtered photo count (e.g. "2 photos tagged newzealand")
- Tags are auto-derived from all photos — no manual configuration needed

## Implementation
- New `GalleryFilter.tsx` client component — manages active tag state and filters the photo list
- Gallery page swaps `GalleryGrid` for `GalleryFilter`
- Home page featured section remains unchanged (uses `GalleryGrid`, links to detail pages)

## Test plan
- [x] `npm run build` passes
- [x] `npm run lint` passes
- [ ] CI workflow passes
- [ ] Manual: click tag → photos filter, click "All" → resets

🤖 Generated with [Claude Code](https://claude.ai/code)