### PR TITLE
feat(blog): add RSS feed

### DIFF
--- a/app/feed/route.ts
+++ b/app/feed/route.ts
@@ -1,0 +1,48 @@
+import { getSortedPosts } from "@/lib/posts";
+
+const SITE_URL = process.env.SITE_URL || "https://hoshino.example.com";
+
+function escapeXml(str: string): string {
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}
+
+export async function GET() {
+  const posts = getSortedPosts();
+
+  const items = posts
+    .map(
+      (post) => `    <item>
+      <title>${escapeXml(post.title)}</title>
+      <link>${SITE_URL}/blog/${post.slug}</link>
+      <guid isPermaLink="true">${SITE_URL}/blog/${post.slug}</guid>
+      <description>${escapeXml(post.excerpt)}</description>
+      <pubDate>${new Date(post.date).toUTCString()}</pubDate>
+      ${post.tags.map((t) => `<category>${escapeXml(t)}</category>`).join("\n      ")}
+    </item>`
+    )
+    .join("\n");
+
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>星野 Hoshino — Blog</title>
+    <link>${SITE_URL}/blog</link>
+    <description>Photography stories, guides, and observations from the night sky.</description>
+    <language>en</language>
+    <atom:link href="${SITE_URL}/feed" rel="self" type="application/rss+xml"/>
+${items}
+  </channel>
+</rss>`;
+
+  return new Response(xml, {
+    headers: {
+      "Content-Type": "application/rss+xml; charset=utf-8",
+      "Cache-Control": "s-maxage=3600, stale-while-revalidate",
+    },
+  });
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -13,6 +13,11 @@ export const metadata: Metadata = {
   description:
     "A photography blog celebrating the night sky — Milky Way, auroras, star trails, and the infinite beauty above us.",
   keywords: ["astrophotography", "night sky", "milky way", "aurora", "stars", "photography blog"],
+  alternates: {
+    types: {
+      "application/rss+xml": "/feed",
+    },
+  },
 };
 
 export default function RootLayout({

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,3 +1,5 @@
+import Link from "next/link";
+
 export default function Footer() {
   const year = new Date().getFullYear();
   return (
@@ -10,7 +12,18 @@ export default function Footer() {
             — A photography blog
           </span>
         </div>
-        <p>© {year} Hoshino. All rights reserved.</p>
+        <div className="flex items-center gap-4">
+          <Link
+            href="/feed"
+            className="hover:text-[var(--text-primary)] transition-colors"
+            title="RSS Feed"
+          >
+            <svg className="w-4 h-4" viewBox="0 0 24 24" fill="currentColor">
+              <path d="M6.18 15.64a2.18 2.18 0 1 1 0 4.36 2.18 2.18 0 0 1 0-4.36zM4 4.44A15.56 15.56 0 0 1 19.56 20h-2.83A12.73 12.73 0 0 0 4 7.27V4.44zm0 5.66a9.9 9.9 0 0 1 9.9 9.9h-2.83A7.07 7.07 0 0 0 4 12.93V10.1z"/>
+            </svg>
+          </Link>
+          <p>© {year} Hoshino. All rights reserved.</p>
+        </div>
       </div>
     </footer>
   );


### PR DESCRIPTION
## Summary
- Adds an **RSS 2.0 feed** at `/feed` generated from blog posts
- Browsers can auto-discover the feed via `<link>` in `<head>`
- RSS icon added to the footer

## Implementation
- `app/feed/route.ts` — Route Handler that renders RSS XML from `getSortedPosts()`
- `app/layout.tsx` — adds `alternates.types` metadata for RSS auto-discovery
- `components/Footer.tsx` — adds RSS icon link
- Site URL configurable via `SITE_URL` env var (defaults to placeholder)

## Test plan
- [x] `npm run build` passes (feed shows as `ƒ /feed` dynamic route)
- [x] `npm run lint` passes
- [ ] CI workflow passes
- [ ] Manual: visit `/feed` → valid RSS XML with blog posts

🤖 Generated with [Claude Code](https://claude.ai/code)