### PR TITLE
feat(nav): add site-wide search (Cmd+K)

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,6 +4,7 @@ import ConditionalStarBackground from "@/components/ConditionalStarBackground";
 import Navigation from "@/components/Navigation";
 import Footer from "@/components/Footer";
 import ThemeProvider from "@/components/ThemeProvider";
+import Search from "@/components/Search";
 
 export const metadata: Metadata = {
   title: {
@@ -32,6 +33,7 @@ export default function RootLayout({
           <main className="flex-1">{children}</main>
           <Footer />
         </div>
+        <Search />
       </body>
     </html>
   );

--- a/components/Navigation.tsx
+++ b/components/Navigation.tsx
@@ -91,6 +91,19 @@ export default function Navigation() {
 
         {/* Right controls */}
         <div className="flex items-center gap-3">
+          {/* Search trigger */}
+          <button
+            onClick={() => document.dispatchEvent(new KeyboardEvent("keydown", { key: "k", metaKey: true }))}
+            className="p-1.5 text-[var(--text-secondary)] hover:text-[var(--text-primary)] transition-colors"
+            aria-label="Search"
+            title="Search (⌘K)"
+          >
+            <svg className="w-5 h-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+              <circle cx="11" cy="11" r="8" />
+              <path d="m21 21-4.3-4.3" />
+            </svg>
+          </button>
+
           {/* Theme picker */}
           <div className="relative" ref={themePickerRef}>
             <button

--- a/components/Search.tsx
+++ b/components/Search.tsx
@@ -1,0 +1,27 @@
+import { getAllPhotos } from "@/lib/photos";
+import { getSortedPosts } from "@/lib/posts";
+import SearchDialog from "./SearchDialog";
+
+export default function Search() {
+  const photos = getAllPhotos();
+  const posts = getSortedPosts();
+
+  const items = [
+    ...photos.map((p) => ({
+      type: "photo" as const,
+      title: p.title,
+      href: `/photos/${p.id}`,
+      subtitle: p.location,
+      tags: p.tags,
+    })),
+    ...posts.map((p) => ({
+      type: "post" as const,
+      title: p.title,
+      href: `/blog/${p.slug}`,
+      subtitle: p.excerpt,
+      tags: p.tags,
+    })),
+  ];
+
+  return <SearchDialog items={items} />;
+}

--- a/components/SearchDialog.tsx
+++ b/components/SearchDialog.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import { useState, useEffect, useCallback, useRef } from "react";
+import Link from "next/link";
+
+interface SearchItem {
+  type: "photo" | "post";
+  title: string;
+  href: string;
+  subtitle: string;
+  tags: string[];
+}
+
+interface SearchDialogProps {
+  items: SearchItem[];
+}
+
+export default function SearchDialog({ items }: SearchDialogProps) {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const results =
+    query.length < 2
+      ? []
+      : items.filter((item) => {
+          const q = query.toLowerCase();
+          return (
+            item.title.toLowerCase().includes(q) ||
+            item.subtitle.toLowerCase().includes(q) ||
+            item.tags.some((t) => t.toLowerCase().includes(q))
+          );
+        });
+
+  const handleClose = useCallback(() => {
+    setOpen(false);
+    setQuery("");
+  }, []);
+
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      if ((e.metaKey || e.ctrlKey) && e.key === "k") {
+        e.preventDefault();
+        setOpen((prev) => !prev);
+      }
+      if (e.key === "Escape" && open) {
+        handleClose();
+      }
+    }
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [open, handleClose]);
+
+  useEffect(() => {
+    if (open) {
+      inputRef.current?.focus();
+      document.body.style.overflow = "hidden";
+    } else {
+      document.body.style.overflow = "";
+    }
+    return () => {
+      document.body.style.overflow = "";
+    };
+  }, [open]);
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-start justify-center pt-[15vh]">
+      <div className="absolute inset-0 bg-black/60 backdrop-blur-sm" onClick={handleClose} />
+      <div className="relative w-full max-w-lg mx-4 glass-card overflow-hidden shadow-2xl">
+        {/* Search input */}
+        <div className="flex items-center gap-3 px-4 py-3 border-b border-[var(--border-subtle)]">
+          <svg className="w-5 h-5 text-[var(--text-muted)] shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+            <circle cx="11" cy="11" r="8" />
+            <path d="m21 21-4.3-4.3" />
+          </svg>
+          <input
+            ref={inputRef}
+            type="text"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Search photos and posts..."
+            className="flex-1 bg-transparent text-[var(--text-primary)] placeholder:text-[var(--text-muted)] outline-none text-sm"
+          />
+          <kbd className="hidden sm:inline-block text-xs px-1.5 py-0.5 rounded border border-[var(--border-subtle)] text-[var(--text-muted)]">
+            Esc
+          </kbd>
+        </div>
+
+        {/* Results */}
+        <div className="max-h-80 overflow-y-auto">
+          {query.length < 2 ? (
+            <p className="px-4 py-6 text-center text-sm text-[var(--text-muted)]">
+              Type at least 2 characters to search
+            </p>
+          ) : results.length === 0 ? (
+            <p className="px-4 py-6 text-center text-sm text-[var(--text-muted)]">
+              No results for &ldquo;{query}&rdquo;
+            </p>
+          ) : (
+            <ul>
+              {results.map((item) => (
+                <li key={item.href}>
+                  <Link
+                    href={item.href}
+                    onClick={handleClose}
+                    className="flex items-center gap-3 px-4 py-3 hover:bg-[var(--glass-bg)] transition-colors"
+                  >
+                    <span className="text-xs px-1.5 py-0.5 rounded bg-[var(--glass-bg)] border border-[var(--border-subtle)] text-[var(--text-muted)] uppercase shrink-0">
+                      {item.type}
+                    </span>
+                    <div className="min-w-0">
+                      <p className="text-sm text-[var(--text-primary)] truncate">{item.title}</p>
+                      <p className="text-xs text-[var(--text-muted)] truncate">{item.subtitle}</p>
+                    </div>
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds a **Cmd+K / Ctrl+K** search dialog accessible from any page
- Searches photos (title, location, tags) and blog posts (title, excerpt, tags)
- Renders as a modal overlay with instant client-side filtering
- Search icon button added to the navigation bar

## Implementation
- `SearchDialog.tsx` — client component with keyboard handling, result rendering
- `Search.tsx` — server component that prepares the search index from photos + posts data
- Navigation updated with search icon trigger
- Layout mounts `<Search />` globally

## Test plan
- [x] `npm run build` passes
- [x] `npm run lint` passes
- [ ] CI workflow passes
- [ ] Manual: Cmd+K opens dialog, typing filters results, clicking a result navigates

🤖 Generated with [Claude Code](https://claude.ai/code)