### PR TITLE
refactor(gallery): manage photos via markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,24 +85,23 @@ hoshino/
 ## 📸 Adding Your Own Photos
 
 1. **Add the image file** to `public/images/` (JPEG or WebP recommended).
-2. **Register the photo** in `lib/photos.ts`:
+2. **Create a markdown file** in `content/photos/` (the filename becomes the URL slug):
 
-```ts
-{
-  id: "my-unique-slug",
-  title: "Title of the photo",
-  description: "A sentence or two about the shot.",
-  location: "City, Country",
-  date: "2024-07-20",
-  tags: ["milky-way", "landscape"],
-  width: 4000,   // actual pixel width (used for aspect-ratio layout)
-  height: 2667,  // actual pixel height
-  src: "/images/my-photo.jpg",
-  featured: true,   // show on home page
-}
+```markdown
+---
+title: "My Photo Title"
+location: "City, Country"
+date: "2024-07-20"
+tags: ["milky-way", "landscape"]
+src: "/images/my-photo.jpg"
+featured: true   # show on home page
+---
+
+A sentence or two about the shot. Full markdown is supported here —
+you can write as much or as little as you like.
 ```
 
-The gallery will automatically arrange photos using CSS columns masonry based on their aspect ratios.
+That's it. Image dimensions are **auto-detected** at build time, so you don't need to specify width/height. The gallery will automatically arrange photos using CSS columns masonry based on their aspect ratios.
 
 ---
 

--- a/content/photos/garden-leaves.md
+++ b/content/photos/garden-leaves.md
@@ -1,0 +1,10 @@
+---
+title: "Garden Leaves"
+location: "N/A"
+date: "2026-04-12"
+tags: ["garden", "leaves"]
+src: "/images/purple-leaves.jpg"
+featured: false
+---
+
+Leaves of the garden

--- a/content/photos/mt-cook.md
+++ b/content/photos/mt-cook.md
@@ -1,0 +1,10 @@
+---
+title: "Mt Cook"
+location: "Mt Cook, New Zealand"
+date: "2024-06-12"
+tags: ["mt-cook", "newzealand"]
+src: "/images/mt-cook.jpg"
+featured: true
+---
+
+Mt Cook in New Zealand

--- a/content/photos/queenstown.md
+++ b/content/photos/queenstown.md
@@ -1,0 +1,10 @@
+---
+title: "Queenstown"
+location: "Queenstown, New Zealand"
+date: "2024-06-11"
+tags: ["queenstown", "newzealand"]
+src: "/images/queenstown.jpg"
+featured: true
+---
+
+Queenstown in New Zealand

--- a/content/photos/roots.md
+++ b/content/photos/roots.md
@@ -1,0 +1,10 @@
+---
+title: "Roots"
+location: "N/A"
+date: "2026-04-11"
+tags: ["roots", "tree"]
+src: "/images/roots.jpg"
+featured: true
+---
+
+Roots of the tree

--- a/lib/photos.ts
+++ b/lib/photos.ts
@@ -1,3 +1,8 @@
+import fs from "fs";
+import path from "path";
+import matter from "gray-matter";
+import sizeOf from "image-size";
+
 export interface Photo {
   id: string;
   title: string;
@@ -5,82 +10,72 @@ export interface Photo {
   location: string;
   date: string;
   tags: string[];
-  /** Width in pixels of the original image (used for layout hints) */
   width: number;
-  /** Height in pixels of the original image (used for layout hints) */
   height: number;
-  /** Path under /public */
   src: string;
-  /** Optional: path to a smaller placeholder */
-  placeholder?: string;
-  featured?: boolean;
+  featured: boolean;
 }
 
-const photos: Photo[] = [
-  {
-    id: "mt-cook",
-    title: "Mt Cook",
-    description:
-      "Mt Cook in New Zealand",
-    location: "Mt Cook, New Zealand",
-    date: "2024-06-12",
-    tags: ["mt-cook", "newzealand"],
-    width: 4000,
-    height: 3000,
-    src: "/images/mt-cook.jpg",
-    featured: true,
-  },
-  {
-    id: "queenstown",
-    title: "Queenstown",
-    description:
-      "Queenstown in New Zealand",
-    location: "Queenstown, New Zealand",
-    date: "2024-06-11",
-    tags: ["queenstown", "newzealand"],
-    width: 4000,
-    height: 3000,
-    src: "/images/queenstown.jpg",
-    featured: true,
-  },
-  {
-    id: "roots",
-    title: "Roots",
-    description:
-      "Roots of the tree",
-    location: "N/A",
-    date: "2026-04-11",
-    tags: ["roots", "tree"],
-    width: 8256,
-    height: 5504,
-    src: "/images/roots.jpg",
-    featured: true,
-  },
-  {
-    id: "garden-leaves",
-    title: "Garden Leaves",
-    description:
-      "Leaves of the garden",
-    location: "N/A",
-    date: "2026-04-12",
-    tags: ["garden", "leaves"],
-    width: 5504,
-    height: 8256,
-    src: "/images/purple-leaves.jpg",
-    featured: false,
-  },
-];
+const photosDirectory = path.join(process.cwd(), "content", "photos");
+const publicDirectory = path.join(process.cwd(), "public");
 
-export default photos;
+let photosCache: Photo[] | null = null;
+
+function loadPhotos(): Photo[] {
+  if (photosCache) return photosCache;
+
+  if (!fs.existsSync(photosDirectory)) return [];
+
+  const files = fs.readdirSync(photosDirectory).filter((f) => f.endsWith(".md"));
+
+  const photos = files.map((file) => {
+    const id = file.replace(/\.md$/, "");
+    const filePath = path.join(photosDirectory, file);
+    const fileContents = fs.readFileSync(filePath, "utf8");
+    const { data, content } = matter(fileContents);
+
+    const src = data.src as string;
+    const imagePath = path.join(publicDirectory, src);
+
+    let width = 0;
+    let height = 0;
+    if (fs.existsSync(imagePath)) {
+      const buffer = fs.readFileSync(imagePath);
+      const dimensions = sizeOf(new Uint8Array(buffer));
+      width = dimensions.width ?? 0;
+      height = dimensions.height ?? 0;
+    }
+
+    return {
+      id,
+      title: data.title ?? id,
+      description: content.trim(),
+      location: data.location ?? "",
+      date: data.date ?? "",
+      tags: data.tags ?? [],
+      width,
+      height,
+      src,
+      featured: data.featured ?? false,
+    };
+  });
+
+  photosCache = photos.sort(
+    (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime()
+  );
+  return photosCache;
+}
+
+export default loadPhotos();
 
 export function getAllPhotos(): Photo[] {
-  return photos;
+  return loadPhotos();
 }
 
 export function getFeaturedPhotos(): Photo[] {
-  return photos.filter((p) => p.featured);
+  return loadPhotos().filter((p) => p.featured);
 }
 
 export function getPhotoById(id: string): Photo | undefined {
-  return photos.find((p) => p.id === id);
+  return loadPhotos().find((p) => p.id === id);
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "gray-matter": "^4.0.3",
+        "image-size": "^2.0.2",
         "next": "16.2.9",
         "react": "19.2.5",
         "react-dom": "19.2.5",
@@ -4927,6 +4928,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/image-size": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/image-size/-/image-size-2.0.2.tgz",
+      "integrity": "sha512-IRqXKlaXwgSMAMtpNzZa1ZAe8m+Sa1770Dhk8VkSsP9LS+iHD62Zd8FQKs8fbPiagBE7BzoFX23cxFnwshpV6w==",
+      "license": "MIT",
+      "bin": {
+        "image-size": "bin/image-size.js"
+      },
+      "engines": {
+        "node": ">=16.x"
       }
     },
     "node_modules/import-fresh": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "gray-matter": "^4.0.3",
+    "image-size": "^2.0.2",
     "next": "16.2.9",
     "react": "19.2.5",
     "react-dom": "19.2.5",


### PR DESCRIPTION
## Summary
- Photos are now managed as **markdown files** in `content/photos/` instead of a hardcoded TypeScript array
- Same workflow as blog posts: create a `.md` file with frontmatter + body
- Image **dimensions are auto-detected** at build time — no need to specify width/height manually

## Adding a new photo

1. Drop the image in `public/images/`
2. Create `content/photos/my-photo.md`:

```markdown
---
title: "My Photo"
location: "City, Country"
date: "2024-08-01"
tags: ["landscape", "travel"]
src: "/images/my-photo.jpg"
featured: true
---

Optional description with full markdown support.
```

That's it. The filename (without `.md`) becomes the photo ID and URL slug.

## What changed
- `lib/photos.ts` — rewritten to read from `content/photos/*.md` using gray-matter + image-size
- `content/photos/` — 4 markdown files migrated from the old hardcoded array
- Added `image-size` dependency for auto dimension detection

## Test plan
- [x] `npm run build` passes — all 4 photo pages generated
- [x] `npm run lint` passes
- [ ] CI workflow passes
- [ ] Manual: photo pages render correctly with descriptions

🤖 Generated with [Claude Code](https://claude.ai/code)